### PR TITLE
Consertando bug do banco de dados dentro do docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,19 @@ services:
     environment:
       NODE_ENV: development
       SERVER_PORT: 4444
-      DB_DATABASE: orion
+      DB_DATABASE: orion-constellation
       DB_CONNECTION_STRING: mysql://orion_constellation_root:j5m966qp7jiypfda@orion-constellation-mysql:3306
     networks:
       - orion-constellation-connect
-  
+    depends_on:
+      orion-constellation-mysql:
+        condition: service_healthy
+
   orion-constellation-mysql:
     container_name: orion-constellation-mysql
     image: mysql
     environment:
-      MYSQL_USER: orion-constellation_root
+      MYSQL_USER: orion_constellation_root
       MYSQL_PASSWORD: j5m966qp7jiypfda
       MYSQL_ROOT_PASSWORD: m45ug42qkr5pdzbb
       MYSQL_DATABASE: orion-constellation
@@ -35,7 +38,12 @@ services:
       - orion-constellation-connect
     logging:
       driver: none
-      
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+
 networks:
   orion-constellation-connect:
     driver: bridge


### PR DESCRIPTION
## Descrição

Durante algumas análises, foi identificado que o comando `docker compose up` gerava um erro de conexão entre os containers da API e do banco de dados. O problema ocorria porque o container da API tentava se conectar ao MySQL antes que este estivesse pronto para aceitar conexões. Este era o erro: 

  ![Erro de conexão](https://github.com/user-attachments/assets/22abfeed-1981-422b-b360-645988c45acc)

Anteriormente, para contornar essa questão, era necessário executar o comando duas vezes. Este PR resolve o problema adicionando uma verificação de saúde no container do MySQL. Agora, o container da API só é iniciado após o MySQL estar totalmente funcional e pronto para conexões.

Com essa modificação, agora o comando `docker compose up` inicializa corretamente todos os serviços em uma única execução:
  
  ![Execução bem-sucedida](https://github.com/user-attachments/assets/bde428e7-1f4f-4f38-8e2b-ebc692265e09)