### PR TITLE
feat: add subject, student and tutor to get responses in lesson request

### DIFF
--- a/src/repository/TutorRepository.ts
+++ b/src/repository/TutorRepository.ts
@@ -3,20 +3,6 @@ import { Tutor } from '../entity/Tutor';
 import { UserRepository } from './UserRepository';
 
 export class TutorRepository extends UserRepository {
-  private static relations = ['educationLevels', 'lessonRequests', 'subjects'];
-  private static selectFields = [
-    'id',
-    'username',
-    'fullName',
-    'photoUrl',
-    'birthDate',
-    'expertise',
-    'projectReason',
-    'educationLevels',
-    'lessonRequests',
-    'subjects'
-  ];
-
   static async saveTutor(tutor: Tutor): Promise<Tutor> {
     const repository = MysqlDataSource.getRepository(Tutor);
     return await repository.save(tutor);
@@ -29,22 +15,23 @@ export class TutorRepository extends UserRepository {
 
   static async findAllTutors() {
     const repository = MysqlDataSource.getRepository(Tutor);
-    return await repository.find({
-      select: Object.fromEntries(
-        this.selectFields.map((field) => [field, true])
-      ),
-      relations: this.relations
-    });
+    return await repository
+      .createQueryBuilder('tutor')
+      .leftJoinAndSelect('tutor.lessonRequests', 'lessonRequest')
+      .leftJoinAndSelect('lessonRequest.subject', 'subject')
+      .leftJoinAndSelect('lessonRequest.tutors', 'tutors')
+      .leftJoinAndSelect('lessonRequest.student', 'student')
+      .getMany();
   }
 
   static async findTutorById(id: number) {
     const repository = MysqlDataSource.getRepository(Tutor);
-    return await repository.findOne({
-      where: { id },
-      select: Object.fromEntries(
-        this.selectFields.map((field) => [field, true])
-      ),
-      relations: this.relations
-    });
+    return await repository
+      .createQueryBuilder('tutor')
+      .leftJoinAndSelect('tutor.lessonRequests', 'lessonRequest')
+      .leftJoinAndSelect('lessonRequest.subject', 'subject')
+      .leftJoinAndSelect('lessonRequest.student', 'student')
+      .where('tutor.id = :id', { id })
+      .getOne();
   }
 }

--- a/src/service/TutorService.ts
+++ b/src/service/TutorService.ts
@@ -10,6 +10,7 @@ import { EnumStatusName } from '../enum/EnumStatusName';
 import { EnumUserType } from '../enum/EnumUserType';
 import { AppError } from '../error/AppError';
 import { handleError } from '../utils/ErrorHandler';
+import { LessonRequestService } from './LessonRequestService';
 
 export class TutorService extends UserService {
   static formatTutor(tutor: Tutor) {
@@ -22,8 +23,12 @@ export class TutorService extends UserService {
       expertise: tutor.expertise,
       projectReason: tutor.projectReason,
       educationLevels: tutor.educationLevels,
-      lessonRequests: tutor.lessonRequests,
-      subjects: tutor.subjects
+      lessonRequests: tutor.lessonRequests
+        ? tutor.lessonRequests.map((lessonRequest) =>
+            LessonRequestService.formatLessonRequest(lessonRequest)
+          )
+        : [],
+      subjects: tutor.subjects ? tutor.subjects : []
     };
   }
 


### PR DESCRIPTION
CHANGES 📝

- Add subject, student and tutor to get responses in lesson request arrays
- Change to use query builder in get queries

NOTE 📝

Branch "feature/add-response-data" -> "feature/update-lesson-status-accepted"

DETAILS 📝
New tutor get all:
![{69CEC0B4-DCBF-4DE4-B6D9-9DC87C600B74}](https://github.com/user-attachments/assets/bf03e69b-9ec7-4bca-ad1a-30681edb5f60)

New tutor get by id:
![{8BAEC0C3-840E-4EF4-BEA7-8E732FE83E3D}](https://github.com/user-attachments/assets/c8c68255-5661-449b-9966-2f396b8aada8)
