### PR TITLE
fix: correct error messages in validators

### DIFF
--- a/src/validator/CommonValidations.ts
+++ b/src/validator/CommonValidations.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcrypt';
 import { UserRepository } from '../repository/UserRepository';
 import { EducationLevelRepository } from '../repository/EducationLevelRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
+import { AppError } from '../error/AppError';
 
 const birthDateRegex =
   /^(0[1-9]|1[0-9]|2[0-9]|3[0-1])\/(0[1-9]|1[0-2])\/\d{4}$/;
@@ -33,12 +34,12 @@ export class CommonValidations {
             await UserRepository.findExistingUserByUsername(value);
 
           if (existingUser) {
-            throw new Error(EnumErrorMessages.USERNAME_ALREADY_EXISTS);
+            throw new AppError(EnumErrorMessages.USERNAME_ALREADY_EXISTS);
           }
 
           return true;
         } catch (error) {
-          throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
         }
       });
   }
@@ -52,7 +53,7 @@ export class CommonValidations {
       .withMessage(EnumErrorMessages.BIRTH_DATE_REQUIRED)
       .custom((value: string): boolean => {
         if (!birthDateRegex.test(value)) {
-          throw new Error(EnumErrorMessages.BIRTH_DATE_FORMAT);
+          throw new AppError(EnumErrorMessages.BIRTH_DATE_FORMAT);
         }
 
         const [day, month, year] = value.split('/').map(Number);
@@ -63,14 +64,14 @@ export class CommonValidations {
               ? true
               : false;
           if (day > 29 || (day === 29 && !isLeapYear)) {
-            throw new Error(EnumErrorMessages.BIRTH_DATE_INCORRECT);
+            throw new AppError(EnumErrorMessages.BIRTH_DATE_INCORRECT);
           }
         } else if (month === 4 || month === 6 || month === 9 || month === 11) {
           if (day > 30) {
-            throw new Error(EnumErrorMessages.BIRTH_DATE_INCORRECT);
+            throw new AppError(EnumErrorMessages.BIRTH_DATE_INCORRECT);
           }
         } else if (day > 31) {
-          throw new Error(EnumErrorMessages.BIRTH_DATE_INCORRECT);
+          throw new AppError(EnumErrorMessages.BIRTH_DATE_INCORRECT);
         }
 
         const now = new Date();
@@ -85,7 +86,7 @@ export class CommonValidations {
         currentDate.setMinutes(currentDate.getMinutes() + offset);
 
         if (inputDate >= currentDate) {
-          throw new Error(EnumErrorMessages.BIRTH_DATE_FUTURE);
+          throw new AppError(EnumErrorMessages.BIRTH_DATE_FUTURE);
         }
 
         return true;
@@ -110,7 +111,7 @@ export class CommonValidations {
       .withMessage(EnumErrorMessages.CONFIRM_PASSWORD_REQUIRED)
       .custom((value, { req }): boolean => {
         if (value !== req.body.password) {
-          throw new Error(EnumErrorMessages.PASSWORDS_NOT_MATCH);
+          throw new AppError(EnumErrorMessages.PASSWORDS_NOT_MATCH);
         }
         return true;
       });
@@ -127,7 +128,7 @@ export class CommonValidations {
       .withMessage(EnumErrorMessages.PASSWORD_MIN_LENGTH)
       .custom((value): boolean => {
         if (!passwordRegex.test(value)) {
-          throw new Error(EnumErrorMessages.PASSWORD_REQUIREMENTS);
+          throw new AppError(EnumErrorMessages.PASSWORD_REQUIREMENTS);
         }
         return true;
       })
@@ -155,12 +156,12 @@ export class CommonValidations {
             await UserRepository.findExistingUserByEmail(value);
 
           if (existingUser) {
-            throw new Error(EnumErrorMessages.EMAIL_ALREADY_EXISTS);
+            throw new AppError(EnumErrorMessages.EMAIL_ALREADY_EXISTS);
           }
 
           return true;
         } catch (error) {
-          throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
         }
       });
   }
@@ -174,18 +175,18 @@ export class CommonValidations {
           const educationLevelIds = req.body.educationLevelIds;
 
           if (educationLevelId.length > 1) {
-            throw new Error(EnumErrorMessages.EDUCATION_LEVEL_SINGLE);
+            throw new AppError(EnumErrorMessages.EDUCATION_LEVEL_SINGLE);
           }
 
           if (
             (!educationLevelId && !educationLevelIds) ||
             (educationLevelId.length === 0 && educationLevelIds.length === 0)
           ) {
-            throw new Error(EnumErrorMessages.EDUCATION_LEVEL_REQUIRED);
+            throw new AppError(EnumErrorMessages.EDUCATION_LEVEL_REQUIRED);
           }
 
           if (educationLevelId && educationLevelIds) {
-            throw new Error(EnumErrorMessages.EDUCATION_LEVEL_CONFLICT);
+            throw new AppError(EnumErrorMessages.EDUCATION_LEVEL_CONFLICT);
           }
 
           const educationLevels =
@@ -198,15 +199,15 @@ export class CommonValidations {
             );
 
           if (existingEducationLevels.length !== parsedValues.length) {
-            throw new Error(EnumErrorMessages.EDUCATION_LEVEL_NOT_EXIST);
+            throw new AppError(EnumErrorMessages.EDUCATION_LEVEL_NOT_EXIST);
           }
 
           return true;
         } catch (error) {
           if (error instanceof Error) {
-            throw new Error(error.message);
+            throw new AppError(error.message);
           }
-          throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
         }
       });
   }

--- a/src/validator/CommonValidations.ts
+++ b/src/validator/CommonValidations.ts
@@ -4,6 +4,7 @@ import { UserRepository } from '../repository/UserRepository';
 import { EducationLevelRepository } from '../repository/EducationLevelRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
 import { AppError } from '../error/AppError';
+import { handleError } from '../utils/ErrorHandler';
 
 const birthDateRegex =
   /^(0[1-9]|1[0-9]|2[0-9]|3[0-1])\/(0[1-9]|1[0-2])\/\d{4}$/;
@@ -39,7 +40,8 @@ export class CommonValidations {
 
           return true;
         } catch (error) {
-          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+          const { statusCode, message } = handleError(error);
+          throw new AppError(message, statusCode);
         }
       });
   }
@@ -161,7 +163,8 @@ export class CommonValidations {
 
           return true;
         } catch (error) {
-          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+          const { statusCode, message } = handleError(error);
+          throw new AppError(message, statusCode);
         }
       });
   }
@@ -204,10 +207,8 @@ export class CommonValidations {
 
           return true;
         } catch (error) {
-          if (error instanceof Error) {
-            throw new AppError(error.message);
-          }
-          throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+          const { statusCode, message } = handleError(error);
+          throw new AppError(message, statusCode);
         }
       });
   }

--- a/src/validator/LessonRequestValidator.ts
+++ b/src/validator/LessonRequestValidator.ts
@@ -5,6 +5,7 @@ import { LessonRequestRepository } from '../repository/LessonRequestRepository';
 import { StudentRepository } from '../repository/StudentRepository';
 import { SubjectRepository } from '../repository/SubjectRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
+import { AppError } from '../error/AppError';
 
 export class LessonRequestValidator {
   static createLessonRequest() {
@@ -19,7 +20,7 @@ export class LessonRequestValidator {
           );
 
           if (!Array.isArray(value)) {
-            throw new Error(invalidReason);
+            throw new AppError(invalidReason);
           }
 
           for (const reason of value) {
@@ -27,7 +28,7 @@ export class LessonRequestValidator {
               typeof reason !== 'string' ||
               !validReasons.includes(reason as EnumReasonName)
             ) {
-              throw new Error(invalidReason);
+              throw new AppError(invalidReason);
             }
           }
           return true;
@@ -50,7 +51,7 @@ export class LessonRequestValidator {
               dateObject.getMonth() + 1 !== parseInt(month) ||
               dateObject.getDate() !== parseInt(day)
             ) {
-              throw new Error(EnumErrorMessages.DATE_INVALID);
+              throw new AppError(EnumErrorMessages.DATE_INVALID);
             }
           }
           return true;
@@ -61,7 +62,7 @@ export class LessonRequestValidator {
 
             const uniqueDates = new Set(value);
             if (uniqueDates.size !== value.length) {
-              throw new Error(EnumErrorMessages.DUPLICATE_PREFERRED_DATES);
+              throw new AppError(EnumErrorMessages.DUPLICATE_PREFERRED_DATES);
             }
 
             await Promise.all(
@@ -73,7 +74,7 @@ export class LessonRequestValidator {
                 const lessonDate = new Date(formattedDate);
                 const now = new Date();
                 if (lessonDate < now) {
-                  throw new Error(
+                  throw new AppError(
                     EnumErrorMessages.PAST_DATE_ERROR.replace('${date}', date)
                   );
                 }
@@ -85,7 +86,7 @@ export class LessonRequestValidator {
                   parseInt(minute) < 0 ||
                   parseInt(minute) > 59
                 ) {
-                  throw new Error(
+                  throw new AppError(
                     EnumErrorMessages.TIME_INVALID.replace('${time}', time)
                   );
                 }
@@ -96,7 +97,7 @@ export class LessonRequestValidator {
                     studentId
                   );
                 if (existingLesson) {
-                  throw new Error(
+                  throw new AppError(
                     EnumErrorMessages.EXISTING_LESSON.replace('${date}', date)
                   );
                 }
@@ -104,7 +105,7 @@ export class LessonRequestValidator {
             );
             return true;
           } catch (error) {
-            throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
           }
         })
         .customSanitizer((value) => {
@@ -125,11 +126,11 @@ export class LessonRequestValidator {
           try {
             const subject = await SubjectRepository.findSubjectById(value);
             if (!subject) {
-              throw new Error(EnumErrorMessages.SUBJECT_NOT_FOUND);
+              throw new AppError(EnumErrorMessages.SUBJECT_NOT_FOUND);
             }
             return true;
           } catch (error) {
-            throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
           }
         }),
       body('studentId')
@@ -141,11 +142,11 @@ export class LessonRequestValidator {
           try {
             const student = await StudentRepository.findStudentById(value);
             if (!student) {
-              throw new Error(EnumErrorMessages.STUDENT_NOT_FOUND);
+              throw new AppError(EnumErrorMessages.STUDENT_NOT_FOUND);
             }
             return true;
           } catch (error) {
-            throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
           }
         }),
       body('additionalInfo')

--- a/src/validator/LessonRequestValidator.ts
+++ b/src/validator/LessonRequestValidator.ts
@@ -6,6 +6,7 @@ import { StudentRepository } from '../repository/StudentRepository';
 import { SubjectRepository } from '../repository/SubjectRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
 import { AppError } from '../error/AppError';
+import { handleError } from '../utils/ErrorHandler';
 
 export class LessonRequestValidator {
   static createLessonRequest() {
@@ -105,7 +106,8 @@ export class LessonRequestValidator {
             );
             return true;
           } catch (error) {
-            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+            const { statusCode, message } = handleError(error);
+            throw new AppError(message, statusCode);
           }
         })
         .customSanitizer((value) => {
@@ -130,7 +132,8 @@ export class LessonRequestValidator {
             }
             return true;
           } catch (error) {
-            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+            const { statusCode, message } = handleError(error);
+            throw new AppError(message, statusCode);
           }
         }),
       body('studentId')
@@ -146,7 +149,8 @@ export class LessonRequestValidator {
             }
             return true;
           } catch (error) {
-            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+            const { statusCode, message } = handleError(error);
+            throw new AppError(message, statusCode);
           }
         }),
       body('additionalInfo')

--- a/src/validator/TutorValidator.ts
+++ b/src/validator/TutorValidator.ts
@@ -5,6 +5,7 @@ import { BaseValidator } from './BaseValidator';
 import { RequestHandler } from 'express';
 import { TutorRepository } from '../repository/TutorRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
+import { AppError } from '../error/AppError';
 
 export class TutorValidator extends CommonValidations {
   /**
@@ -31,11 +32,11 @@ export class TutorValidator extends CommonValidations {
           try {
             const cleanCpf = value.replace(/\D/g, '');
             if (!cpf.isValid(cleanCpf)) {
-              throw new Error(EnumErrorMessages.CPF_INVALID);
+              throw new AppError(EnumErrorMessages.CPF_INVALID);
             }
             return true;
           } catch (error) {
-            throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
           }
         })
         .custom(async (value: string): Promise<boolean> => {
@@ -45,12 +46,12 @@ export class TutorValidator extends CommonValidations {
               await TutorRepository.findTutorByCpf(cleanCpf);
 
             if (existingTutor) {
-              throw new Error(EnumErrorMessages.CPF_ALREADY_EXISTS);
+              throw new AppError(EnumErrorMessages.CPF_ALREADY_EXISTS);
             }
 
             return true;
           } catch (error) {
-            throw new Error(EnumErrorMessages.INTERNAL_SERVER);
+            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
           }
         })
         .customSanitizer((value: string): string => {

--- a/src/validator/TutorValidator.ts
+++ b/src/validator/TutorValidator.ts
@@ -6,6 +6,7 @@ import { RequestHandler } from 'express';
 import { TutorRepository } from '../repository/TutorRepository';
 import { EnumErrorMessages } from '../enum/EnumErrorMessages';
 import { AppError } from '../error/AppError';
+import { handleError } from '../utils/ErrorHandler';
 
 export class TutorValidator extends CommonValidations {
   /**
@@ -36,7 +37,8 @@ export class TutorValidator extends CommonValidations {
             }
             return true;
           } catch (error) {
-            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+            const { statusCode, message } = handleError(error);
+            throw new AppError(message, statusCode);
           }
         })
         .custom(async (value: string): Promise<boolean> => {
@@ -51,7 +53,8 @@ export class TutorValidator extends CommonValidations {
 
             return true;
           } catch (error) {
-            throw new AppError(EnumErrorMessages.INTERNAL_SERVER);
+            const { statusCode, message } = handleError(error);
+            throw new AppError(message, statusCode);
           }
         })
         .customSanitizer((value: string): string => {


### PR DESCRIPTION
CHANGES 📝

Fix error messages in validators

NOTE 📝
Branch "fix/validation-responses" -> "develop"

DETAILS 📝
Correct error messages:
![{51E7CCF3-6B46-4EC0-ACAD-AF6F81FA4D35}](https://github.com/user-attachments/assets/9007704e-1f9a-4616-8e6a-8e265abfa724)
